### PR TITLE
fix removal of excess tab buttons

### DIFF
--- a/KPCTabsControl/TabsControl.swift
+++ b/KPCTabsControl/TabsControl.swift
@@ -140,7 +140,7 @@ open class TabsControl: NSControl, NSTextDelegate {
         let newItemsCount = dataSource.tabsControlNumberOfTabs(self)
         
         if newItemsCount < oldItemsCount {
-            self.tabButtons.filter({ $0.index >= self.tabButtons.count }).forEach({ $0.removeFromSuperview() })
+            self.tabButtons.filter({ $0.index >= newItemsCount }).forEach({ $0.removeFromSuperview() })
         }
         
         var tabButtons = self.tabButtons


### PR DESCRIPTION
When items are removed from the data source, excess tab buttons did not get removed because the condition compared to the wrong count (the old instead of the new).