### PR TITLE
Fixes resources under SPM

### DIFF
--- a/KPCTabsControl/NSButton+TabsControl.swift
+++ b/KPCTabsControl/NSButton+TabsControl.swift
@@ -23,8 +23,15 @@ extension NSButton {
         button.isEnabled = (target != nil && action != nil)
         button.isContinuous = true
         button.imagePosition = .imageOnly
+        #if SwiftPackage
+        button.image = NSImage(
+            contentsOfFile: Bundle.module.path(
+                forResource: imageName, ofType: "pdf", inDirectory: "Resources"
+            )!
+        )
+        #else
         button.image = NSImage(named: NSImage.Name(imageName))
-
+        #endif
         if let img = button.image {
             var r: CGRect = CGRect.zero
             r.size = img.size

--- a/KPCTabsControl/Resources
+++ b/KPCTabsControl/Resources
@@ -1,0 +1,1 @@
+../Resources

--- a/KPCTabsControl/TabButtonCell.swift
+++ b/KPCTabsControl/TabButtonCell.swift
@@ -69,7 +69,12 @@ class TabButtonCell: NSButtonCell {
     // MARK: - Properties & Rects
 
     static func popupImage() -> NSImage {
-        let path = Bundle(for: self).pathForImageResource(NSImage.Name("KPCPullDownTemplate"))!
+        let path: String
+        #if SwiftPackage
+        path = Bundle.module.path(forResource: "KPCPullDownTemplate", ofType: "pdf", inDirectory: "Resources")!
+        #else
+        path = Bundle(for: self).pathForImageResource(NSImage.Name("KPCPullDownTemplate"))!
+        #endif
         return NSImage(contentsOfFile: path)!.imageWithTint(NSColor.darkGray)
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,8 +21,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "KPCTabsControl",
-            dependencies: [],
-            path: "KPCTabsControl"
+            path: "KPCTabsControl",
+            resources: [
+                .copy("Resources")
+            ],
+            swiftSettings: [.define("SwiftPackage")]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Accessing resources under SPM works differently than in frameworks and app bundles. When using KPCTabsControl via SwiftPM the code crashes whenever a resource is being loaded (because the code assumes the resource files will be always present):

![image](https://github.com/onekiloparsec/KPCTabsControl/assets/633862/8a5de366-21d4-4cc7-8b09-71b225e2b6d5)

This PR features the following changes:

 - updates Package.swift to include package resource files
 - adds a symlink to the Resources folder to satisfy SPM's requirement that the resources are found under the target path
 - adds a Swift flag when compiled as a package
 - uses `Bundle.module` conditionally when compiled as a package

