### PR TITLE
Clean up Swift code

### DIFF
--- a/KPCTabsControl/ChromeStyle.swift
+++ b/KPCTabsControl/ChromeStyle.swift
@@ -12,14 +12,14 @@ public struct ChromeStyle: ThemedStyle {
     public let theme: Theme
     public let tabButtonWidth: TabWidth
     public let tabsControlRecommendedHeight: CGFloat = 34.0
-    
+
     public init(theme: Theme = ChromeTheme(), tabButtonWidth: TabWidth = .flexible(min: 80, max: 180)) {
         self.theme = theme
         self.tabButtonWidth = tabButtonWidth
     }
 
     public func iconFrames(tabRect rect: NSRect) -> IconFrames {
-        
+
         let paddedHeight = PaddedHeight.fromFrame(rect)
         let topPadding = paddedHeight.topPadding
         let iconHeight = paddedHeight.iconHeight
@@ -27,10 +27,10 @@ public struct ChromeStyle: ThemedStyle {
 
         // Left border is angled at 45˚, so it grows proportionally wider
         let iconXOffset = paddedHeight.value / 2
-        
+
         return (
-            NSMakeRect(iconXOffset, topPadding, iconHeight, iconHeight),
-            NSMakeRect(x, topPadding, iconHeight, iconHeight)
+            NSRect(x: iconXOffset, y: topPadding, width: iconHeight, height: iconHeight),
+            NSRect(x: x, y: topPadding, width: iconHeight, height: iconHeight)
         )
     }
 
@@ -126,7 +126,7 @@ public struct ChromeStyle: ThemedStyle {
         let height: CGFloat = PaddedHeight.fromFrame(frame).value
         let xOffset = height / 2.0
         let curve = CGFloat(4)
-        
+
         let lowerLeft  = frame.origin + Offset(y: frame.height)
         let upperLeft  = lowerLeft + Offset(x: xOffset, y: -height - 0.5)
         let lowerRight = lowerLeft + Offset(x: frame.width - 1)
@@ -134,10 +134,10 @@ public struct ChromeStyle: ThemedStyle {
 
         // Let's build tab path
         let path = NSBezierPath()
-        
+
         // Lower left point.
         path.move(to: lowerLeft)
-        
+
         // Before aligning to the top, make a slight curve.
         let leftRisingFromPoint = lowerLeft + Offset(x: curve)
         let leftRisingToPoint = lowerLeft + Offset(x: curve, y: -curve)
@@ -146,14 +146,14 @@ public struct ChromeStyle: ThemedStyle {
         // Before reaching the top, stop at the point of the coming curve
         let leftToppingPoint = upperLeft + Offset(x: -curve, y: curve)
         path.line(to: leftToppingPoint)
-        
+
         // Curve to the top!
         let leftToppingFromPoint = upperLeft + Offset(x: -curve)
         path.appendArc(from: leftToppingFromPoint, to: upperLeft, radius: curve)
 
         // Line to the upper right
         path.line(to: upperRight)
-        
+
         // Before aligning to fall down, make a slight curve
         let rightFallingFromPoint = upperRight + Offset(x: curve)
         let rightFallingToPoint = upperRight + Offset(x: curve, y: curve)
@@ -162,7 +162,7 @@ public struct ChromeStyle: ThemedStyle {
         // Before reaching the bottom right, stop at the point of the coming curve
         let rightBottomingPoint = lowerRight + Offset(x: -curve, y: -curve)
         path.line(to: rightBottomingPoint)
-        
+
         // Curve to the bottom
         let rightBottomingFromPoint = lowerRight + Offset(x: -curve)
         path.appendArc(from: rightBottomingFromPoint, to: lowerRight, radius: curve)
@@ -190,7 +190,7 @@ public struct ChromeStyle: ThemedStyle {
     fileprivate func drawBottomBorder(frame: NSRect) {
         let bottomBorder = NSRect(origin: frame.origin + Offset(y: frame.height - 1),
                                   size: NSSize(width: frame.width, height: 1))
-        
+
         self.theme.tabsControlTheme.borderColor.setFill()
         bottomBorder.fill()
     }

--- a/KPCTabsControl/ChromeTheme.swift
+++ b/KPCTabsControl/ChromeTheme.swift
@@ -16,31 +16,31 @@ public struct ChromeTheme: Theme {
     public let selectedTabButtonTheme: TabButtonTheme = SelectedTabButtonTheme(base: DefaultTabButtonTheme())
     public let unselectableTabButtonTheme: TabButtonTheme = UnselectableTabButtonTheme(base: DefaultTabButtonTheme())
     public let tabsControlTheme: TabsControlTheme = DefaultTabsControlTheme()
-    
+
     fileprivate static var sharedBorderColor: NSColor { return NSColor(calibratedWhite: 152/256.0, alpha: 1.0) }
     fileprivate static var sharedBackgroundColor: NSColor { return NSColor(calibratedWhite: 216/256.0, alpha: 1.0) }
 
     fileprivate struct DefaultTabButtonTheme: KPCTabsControl.TabButtonTheme {
-        
+
         var backgroundColor: NSColor { return ChromeTheme.sharedBackgroundColor }
         var borderColor: NSColor { return ChromeTheme.sharedBorderColor }
         var titleColor: NSColor { return NSColor.controlTextColor }
         var titleFont: NSFont { return NSFont.systemFont(ofSize: 14) }
     }
-    
+
     fileprivate struct SelectedTabButtonTheme: KPCTabsControl.TabButtonTheme {
-        
+
         let base: DefaultTabButtonTheme
-        
+
         var backgroundColor: NSColor { return NSColor(calibratedWhite: 245/256.0, alpha: 1.0) }
         var borderColor: NSColor { return base.borderColor }
         var titleColor: NSColor { return base.titleColor }
         var titleFont: NSFont { return base.titleFont }
     }
-    
+
     fileprivate struct UnselectableTabButtonTheme: KPCTabsControl.TabButtonTheme {
         let base: DefaultTabButtonTheme
-        
+
         var backgroundColor: NSColor { return base.backgroundColor }
         var borderColor: NSColor { return base.borderColor }
         var titleColor: NSColor { return NSColor.lightGray }
@@ -48,7 +48,7 @@ public struct ChromeTheme: Theme {
     }
 
     fileprivate struct DefaultTabsControlTheme: KPCTabsControl.TabsControlTheme {
-        
+
         var borderColor: NSColor { return ChromeTheme.sharedBorderColor }
         var backgroundColor: NSColor { return ChromeTheme.sharedBackgroundColor }
     }

--- a/KPCTabsControl/Constants.swift
+++ b/KPCTabsControl/Constants.swift
@@ -22,7 +22,7 @@ public enum TabPosition {
     case first
     case middle
     case last
-    
+
     /**
      Convenience function to get TabPosition from a given index compared to a given total count.
      
@@ -64,21 +64,20 @@ public enum TabSelectionState {
     case unselectable
 }
 
-
 /**
  *  Border mask option set, used in tab buttons and the tabs control itself.
  */
 public struct BorderMask: OptionSet {
     public let rawValue: Int
-    
+
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    
+
     public static func all() -> BorderMask {
         return BorderMask.top.union(BorderMask.left).union(BorderMask.right).union(BorderMask.bottom)
     }
-    
+
     public static let top = BorderMask(rawValue: 1 << 0)
     public static let left = BorderMask(rawValue: 1 << 1)
     public static let right = BorderMask(rawValue: 1 << 2)

--- a/KPCTabsControl/DefaultStyle.swift
+++ b/KPCTabsControl/DefaultStyle.swift
@@ -16,9 +16,9 @@ public enum TitleDefaults {
 /// Default implementation of Themed Style
 
 extension ThemedStyle {
-    
+
     // MARK: - Tab Buttons
-    
+
     public func tabButtonOffset(position: TabPosition) -> Offset {
         return NSPoint()
     }
@@ -26,64 +26,64 @@ extension ThemedStyle {
     public func tabButtonBorderMask(_ position: TabPosition) -> BorderMask? {
         return BorderMask.all()
     }
-    
+
     // MARK: - Tab Button Titles
 
     public func iconFrames(tabRect rect: NSRect) -> IconFrames {
-        
+
         let verticalPadding: CGFloat = 4.0
         let paddedHeight = rect.height - 2*verticalPadding
         let x = rect.width / 2.0 - paddedHeight / 2.0
-        
-        return (NSMakeRect(10.0, verticalPadding, paddedHeight, paddedHeight),
-                NSMakeRect(x, verticalPadding, paddedHeight, paddedHeight))
+
+        return (NSRect(x: 10.0, y: verticalPadding, width: paddedHeight, height: paddedHeight),
+                NSRect(x: x, y: verticalPadding, width: paddedHeight, height: paddedHeight))
     }
-        
+
     public func titleRect(title: NSAttributedString, inBounds rect: NSRect, showingIcon: Bool) -> NSRect {
-        
+
         let titleSize = title.size()
-        let fullWidthRect = NSRect(x: NSMinX(rect),
-                                   y: NSMidY(rect) - titleSize.height/2.0 - 0.5,
-                                   width: NSWidth(rect),
+        let fullWidthRect = NSRect(x: rect.minX,
+                                   y: rect.midY - titleSize.height/2.0 - 0.5,
+                                   width: rect.width,
                                    height: titleSize.height)
-        
+
         return self.paddedRectForIcon(fullWidthRect, showingIcon: showingIcon)
     }
-    
+
     fileprivate func paddedRectForIcon(_ rect: NSRect, showingIcon: Bool) -> NSRect {
-        
+
         guard showingIcon else {
             return rect
         }
-        
+
         let iconRect = self.iconFrames(tabRect: rect).iconFrame
-        let pad = NSMaxX(iconRect)+titleMargin
+        let pad = iconRect.maxX+titleMargin
         return rect.offsetBy(dx: pad, dy: 0.0).shrinkBy(dx: pad, dy: 0.0)
     }
-    
+
     public func titleEditorSettings() -> TitleEditorSettings {
         return (textColor: NSColor(calibratedWhite: 1.0/6, alpha: 1.0),
                 font: self.theme.tabButtonTheme.titleFont,
                 alignment: TitleDefaults.alignment)
     }
-    
+
     public func attributedTitle(content: String, selectionState: TabSelectionState) -> NSAttributedString {
-        
+
         let activeTheme = self.theme.tabButtonTheme(fromSelectionState: selectionState)
-        
+
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = TitleDefaults.alignment
         paragraphStyle.lineBreakMode = TitleDefaults.lineBreakMode
-        
-        let attributes = [NSAttributedString.Key.foregroundColor : activeTheme.titleColor,
-                          NSAttributedString.Key.font : activeTheme.titleFont,
-                          NSAttributedString.Key.paragraphStyle : paragraphStyle]
-        
+
+        let attributes = [NSAttributedString.Key.foregroundColor: activeTheme.titleColor,
+                          NSAttributedString.Key.font: activeTheme.titleFont,
+                          NSAttributedString.Key.paragraphStyle: paragraphStyle]
+
         return NSAttributedString(string: content, attributes: attributes)
     }
 
     // MARK: - Tabs Control
-    
+
     public func tabsControlBorderMask() -> BorderMask? {
         return BorderMask.top.union(BorderMask.bottom)
     }
@@ -93,26 +93,26 @@ extension ThemedStyle {
     public func drawTabsControlBezel(frame: NSRect) {
         self.theme.tabsControlTheme.backgroundColor.setFill()
         frame.fill()
-        
+
         let borderDrawing = BorderDrawing.fromMask(frame, borderMask: self.tabsControlBorderMask())
         self.drawBorder(borderDrawing, color: self.theme.tabsControlTheme.borderColor)
     }
-    
+
     public func drawTabButtonBezel(frame: NSRect, position: TabPosition, isSelected: Bool) {
-        
+
         let activeTheme = isSelected ? self.theme.selectedTabButtonTheme : self.theme.tabButtonTheme
         activeTheme.backgroundColor.setFill()
         frame.fill()
-        
+
         let borderDrawing = BorderDrawing.fromMask(frame, borderMask: self.tabButtonBorderMask(position))
         self.drawBorder(borderDrawing, color: activeTheme.borderColor)
     }
 
     fileprivate func drawBorder(_ border: BorderDrawing, color: NSColor) {
-        
+
         guard case let .draw(borderRects: borderRects, rectCount: _) = border
             else { return }
-        
+
         color.setFill()
         color.setStroke()
         borderRects.fill()
@@ -124,15 +124,15 @@ extension ThemedStyle {
 private enum BorderDrawing {
     case empty
     case draw(borderRects: [NSRect], rectCount: Int)
-    
+
     fileprivate static func fromMask(_ sourceRect: NSRect, borderMask: BorderMask?) -> BorderDrawing {
-        
+
         guard let mask = borderMask else { return .empty }
 
         var outputCount: Int = 0
-        var remainderRect = NSZeroRect
-        var borderRects: [NSRect] = [NSZeroRect, NSZeroRect, NSZeroRect, NSZeroRect]
-        
+        var remainderRect = NSRect.zero
+        var borderRects: [NSRect] = [NSRect.zero, NSRect.zero, NSRect.zero, NSRect.zero]
+
         if mask.contains(.top) {
             NSDivideRect(sourceRect, &borderRects[outputCount], &remainderRect, 0.5, .minY)
             outputCount += 1
@@ -149,9 +149,9 @@ private enum BorderDrawing {
             NSDivideRect(sourceRect, &borderRects[outputCount], &remainderRect, 0.5, .maxY)
             outputCount += 1
         }
-        
+
         guard outputCount > 0 else { return .empty }
-        
+
         return .draw(borderRects: borderRects, rectCount: outputCount)
     }
 }
@@ -171,4 +171,3 @@ public struct DefaultStyle: ThemedStyle {
         self.tabButtonWidth = tabButtonWidth
     }
 }
-

--- a/KPCTabsControl/DefaultTheme.swift
+++ b/KPCTabsControl/DefaultTheme.swift
@@ -14,7 +14,7 @@ import Cocoa
 public struct DefaultTheme: Theme {
 
     public init() { }
-    
+
     public let tabButtonTheme: TabButtonTheme = DefaultTabButtonTheme()
     public let selectedTabButtonTheme: TabButtonTheme = SelectedTabButtonTheme(base: DefaultTabButtonTheme())
     public let unselectableTabButtonTheme: TabButtonTheme = UnselectableTabButtonTheme(base: DefaultTabButtonTheme())
@@ -42,13 +42,13 @@ public struct DefaultTheme: Theme {
 
     fileprivate struct UnselectableTabButtonTheme: KPCTabsControl.TabButtonTheme {
         let base: DefaultTabButtonTheme
-        
+
         var backgroundColor: NSColor { return base.backgroundColor }
         var borderColor: NSColor { return base.borderColor }
         var titleColor: NSColor { return NSColor.lightGray }
         var titleFont: NSFont { return base.titleFont }
     }
-    
+
     fileprivate struct DefaultTabsControlTheme: KPCTabsControl.TabsControlTheme {
         var backgroundColor: NSColor { return DefaultTheme.sharedBackgroundColor }
         var borderColor: NSColor { return DefaultTheme.sharedBorderColor }

--- a/KPCTabsControl/Error.swift
+++ b/KPCTabsControl/Error.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-func fatalMethodNotImplemented(_ function: String = #function) -> Never  {
+func fatalMethodNotImplemented(_ function: String = #function) -> Never {
     fatalError("Method \(function) not implemented")
 }

--- a/KPCTabsControl/Helpers.swift
+++ b/KPCTabsControl/Helpers.swift
@@ -12,13 +12,13 @@ import Foundation
 public typealias Offset = NSPoint
 
 extension Offset {
-    
+
     public init(x: CGFloat) {
         self.init()
         self.x = x
         self.y = 0
     }
-    
+
     public init(y: CGFloat) {
         self.init()
         self.x = 0
@@ -42,9 +42,9 @@ public func +(lhs: NSPoint, rhs: Offset) -> NSPoint {
  A convenience extension to easily shrink a NSRect
  */
 extension NSRect {
-    
+
     /// Change width and height by `-dx` and `-dy`.
-    
+
     public func shrinkBy(dx: CGFloat, dy: CGFloat) -> NSRect {
         var result = self
         result.size = CGSize(width: result.size.width - dx, height: result.size.height - dy)
@@ -64,10 +64,9 @@ func ==(t1: TabWidth, t2: TabWidth) -> Bool {
     return String(describing: t1) == String(describing: t2)
 }
 
-
 /// Helper functions to let compare optionals
 
-func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     switch (lhs, rhs) {
     case let (l?, r?):
         return l < r
@@ -78,7 +77,7 @@ func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 }
 
-func >= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+func >= <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     switch (lhs, rhs) {
     case let (l?, r?):
         return l >= r
@@ -87,7 +86,7 @@ func >= <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 }
 
-func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l > r

--- a/KPCTabsControl/MessageInterceptor.swift
+++ b/KPCTabsControl/MessageInterceptor.swift
@@ -8,19 +8,19 @@
 
 import Foundation
 
-internal class MessageInterceptor : NSObject {
-    var receiver: NSObject?;
-    var middleMan: NSObject?;
-    
+internal class MessageInterceptor: NSObject {
+    var receiver: NSObject?
+    var middleMan: NSObject?
+
     override func forwardingTarget(for aSelector: Selector) -> Any? {
         if self.middleMan?.responds(to: aSelector) == true { return self.middleMan }
         if self.receiver?.responds(to: aSelector) == true { return self.receiver }
         return super.forwardingTarget(for: aSelector)
     }
-    
+
     override func responds(to aSelector: Selector) -> Bool {
         if self.middleMan?.responds(to: aSelector) == true { return true }
         if self.receiver?.responds(to: aSelector) == true { return true }
         return super.responds(to: aSelector)
-    }    
+    }
 }

--- a/KPCTabsControl/NSButton+TabsControl.swift
+++ b/KPCTabsControl/NSButton+TabsControl.swift
@@ -10,11 +10,11 @@ import AppKit
 
 extension NSButton {
     static internal func auxiliaryButton(withImageNamed imageName: String, target: AnyObject?, action: Selector?) -> NSButton {
-        
+
         let cell = TabButtonCell(textCell: "")
         let mask = NSEvent.EventTypeMask.leftMouseDown.union(NSEvent.EventTypeMask.periodic)
         cell.sendAction(on: NSEvent.EventTypeMask(rawValue: UInt64(Int(mask.rawValue))))
-        
+
         let button = NSButton()
         button.cell = cell
 
@@ -38,7 +38,7 @@ extension NSButton {
             r.size.width += 4.0
             button.frame = r
         }
-        
+
         return button
-    }    
+    }
 }

--- a/KPCTabsControl/NSImage+TabsControl.swift
+++ b/KPCTabsControl/NSImage+TabsControl.swift
@@ -10,20 +10,20 @@ import AppKit
 
 extension NSImage {
     internal func imageWithTint(_ tint: NSColor) -> NSImage {
-        var imageRect = NSZeroRect;
-        imageRect.size = self.size;
-        
+        var imageRect = NSRect.zero
+        imageRect.size = self.size
+
         let highlightImage = NSImage(size: imageRect.size)
-        
+
         highlightImage.lockFocus()
-        
-        self.draw(in: imageRect, from: NSZeroRect, operation: .sourceOver, fraction: 1.0)
-        
+
+        self.draw(in: imageRect, from: NSRect.zero, operation: .sourceOver, fraction: 1.0)
+
         tint.set()
-        imageRect.fill(using: .sourceAtop);
-        
+        imageRect.fill(using: .sourceAtop)
+
         highlightImage.unlockFocus()
-        
-        return highlightImage;
+
+        return highlightImage
     }
 }

--- a/KPCTabsControl/Protocols.swift
+++ b/KPCTabsControl/Protocols.swift
@@ -17,7 +17,7 @@ import AppKit
      - returns: A unsigned integer indicating the number of tabs to display.
      */
     func tabsControlNumberOfTabs(_ control: TabsControl) -> Int
-    
+
     /**
      Return the item for the tab at the given index, similarly to a "representedObject" in a cell view.
      
@@ -27,7 +27,7 @@ import AppKit
      - returns: An instance of an object representing the tab.
      */
     func tabsControl(_ control: TabsControl, itemAtIndex index: Int) -> AnyObject
-    
+
     /**
      Return the title for the tab of the given item
      
@@ -37,7 +37,7 @@ import AppKit
      - returns: A string to be used as title of the tab.
      */
     func tabsControl(_ control: TabsControl, titleForItem item: AnyObject) -> String
-    
+
     /**
      If any, returns a menu for the tab, to be place to the right side of it. It is your responsability to fully
      configure its targets and actions before returning it to the tabs control.
@@ -47,8 +47,8 @@ import AppKit
      
      - returns: A menu instance.
      */
-    @objc optional func tabsControl(_ control: TabsControl, menuForItem item:AnyObject) -> NSMenu?
-    
+    @objc optional func tabsControl(_ control: TabsControl, menuForItem item: AnyObject) -> NSMenu?
+
     /**
      If any, returns an icon for the tab, to be placed to the left side of it.
      
@@ -57,7 +57,7 @@ import AppKit
      
      - returns: An image instance for the icon.
      */
-    @objc optional func tabsControl(_ control: TabsControl, iconForItem item:AnyObject) -> NSImage?
+    @objc optional func tabsControl(_ control: TabsControl, iconForItem item: AnyObject) -> NSImage?
 
     /**
      If the width of the tab is not large enough to draw the title, it is possible to provide here an alternate
@@ -69,7 +69,7 @@ import AppKit
      
      - returns:  An image instance for the alternate icon.
      */
-    @objc optional func tabsControl(_ control: TabsControl, titleAlternativeIconForItem item:AnyObject) -> NSImage?
+    @objc optional func tabsControl(_ control: TabsControl, titleAlternativeIconForItem item: AnyObject) -> NSImage?
 }
 
 @objc public protocol TabsControlDelegate: NSControlTextEditingDelegate {

--- a/KPCTabsControl/SafariStyle.swift
+++ b/KPCTabsControl/SafariStyle.swift
@@ -15,17 +15,17 @@ public struct SafariStyle: ThemedStyle {
     public let theme: Theme
     public let tabButtonWidth: TabWidth
     public let tabsControlRecommendedHeight: CGFloat = 24.0
-    
+
     public init(theme: Theme = SafariTheme(), tabButtonWidth: TabWidth = .full) {
         self.theme = theme
         self.tabButtonWidth = tabButtonWidth
     }
-    
+
     // There is no icons in Safari tabs. Here we force the absence of icon, even if some are provided.
     public func iconFrames(tabRect rect: NSRect) -> IconFrames {
-        return (NSZeroRect, NSZeroRect)
+        return (NSRect.zero, NSRect.zero)
     }
-    
+
     public func tabButtonBorderMask(_ position: TabPosition) -> BorderMask? {
         return [.bottom, .top, .right]
     }
@@ -34,4 +34,3 @@ public struct SafariStyle: ThemedStyle {
         return BorderMask.all()
     }
 }
-

--- a/KPCTabsControl/SafariTheme.swift
+++ b/KPCTabsControl/SafariTheme.swift
@@ -9,24 +9,24 @@
 import AppKit
 
 public struct SafariTheme: Theme {
-    
+
     public init() { }
-    
+
     public let tabButtonTheme: TabButtonTheme = DefaultTabButtonTheme()
     public let selectedTabButtonTheme: TabButtonTheme = SelectedTabButtonTheme()
     public let unselectableTabButtonTheme: TabButtonTheme = UnselectableTabButtonTheme(base: DefaultTabButtonTheme())
     public let tabsControlTheme: TabsControlTheme = DefaultTabsControlTheme()
-    
+
     fileprivate static var sharedBackgroundColor: NSColor { return NSColor(white: 0.72, alpha: 1.0) }
     fileprivate static var sharedBorderColor: NSColor { return NSColor(white: 0.61, alpha: 1.0) }
-    
+
     fileprivate struct DefaultTabButtonTheme: KPCTabsControl.TabButtonTheme {
         var backgroundColor: NSColor { return SafariTheme.sharedBackgroundColor }
         var borderColor: NSColor { return SafariTheme.sharedBorderColor }
         var titleColor: NSColor { return NSColor(white: 0.38, alpha: 1.0) }
         var titleFont: NSFont { return NSFont.systemFont(ofSize: NSFont.systemFontSize) }
     }
-    
+
     fileprivate struct SelectedTabButtonTheme: KPCTabsControl.TabButtonTheme {
         var backgroundColor: NSColor { return NSColor(white: 0.79, alpha: 1.0) }
         var borderColor: NSColor { return NSColor(white: 0.64, alpha: 1.0) }
@@ -36,7 +36,7 @@ public struct SafariTheme: Theme {
 
     fileprivate struct UnselectableTabButtonTheme: KPCTabsControl.TabButtonTheme {
         let base: DefaultTabButtonTheme
-        
+
         var backgroundColor: NSColor { return base.backgroundColor }
         var borderColor: NSColor { return base.borderColor }
         var titleColor: NSColor { return NSColor(white: 0.94, alpha: 1.0) }

--- a/KPCTabsControl/SequenceType+TabsControl.swift
+++ b/KPCTabsControl/SequenceType+TabsControl.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Sequence {    
+extension Sequence {
     internal func findFirst(_ predicate: (Self.Iterator.Element) -> Bool) -> Self.Iterator.Element? {
 
         for element in self {

--- a/KPCTabsControl/Style.swift
+++ b/KPCTabsControl/Style.swift
@@ -20,7 +20,7 @@ public protocol Style {
     var tabButtonWidth: TabWidth { get }
     func tabButtonOffset(position: TabPosition) -> Offset
     func tabButtonBorderMask(_ position: TabPosition) -> BorderMask?
-    
+
     // Tab Button Titles
     func iconFrames(tabRect rect: NSRect) -> IconFrames
     func titleRect(title: NSAttributedString, inBounds rect: NSRect, showingIcon: Bool) -> NSRect
@@ -30,7 +30,7 @@ public protocol Style {
     // Tabs Control
     var tabsControlRecommendedHeight: CGFloat { get }
     func tabsControlBorderMask() -> BorderMask?
-    
+
     // Drawing
     func drawTabButtonBezel(frame: NSRect, position: TabPosition, isSelected: Bool)
     func drawTabsControlBezel(frame: NSRect)
@@ -40,6 +40,6 @@ public protocol Style {
  *  The default Style protocol doesn't necessary have a theme associated with it, for custom styles.
  *  However, provided styles (Numbers.app-like, Safari and Chrome) have an associated theme.
  */
-public protocol ThemedStyle : Style {
+public protocol ThemedStyle: Style {
     var theme: Theme { get }
 }

--- a/KPCTabsControl/TabButton.swift
+++ b/KPCTabsControl/TabButton.swift
@@ -13,7 +13,7 @@ open class TabButton: NSButton {
     fileprivate var iconView: NSImageView?
     fileprivate var alternativeTitleIconView: NSImageView?
     fileprivate var trackingArea: NSTrackingArea?
-    
+
     fileprivate var tabButtonCell: TabButtonCell? {
         get { return self.cell as? TabButtonCell }
     }
@@ -28,7 +28,7 @@ open class TabButton: NSButton {
     }
 
     /// The button is aware of its last known index in the tab bar.
-    var index: Int? = nil
+    var index: Int?
 
     open var buttonPosition: TabPosition! {
         get { return tabButtonCell?.buttonPosition }
@@ -45,14 +45,13 @@ open class TabButton: NSButton {
         set { self.tabButtonCell?.isEditable = newValue }
     }
 
-    open var icon: NSImage? = nil {
+    open var icon: NSImage? {
         didSet {
             if self.icon != nil && self.iconView == nil {
-                self.iconView = NSImageView(frame: NSZeroRect)
+                self.iconView = NSImageView(frame: NSRect.zero)
                 self.iconView?.imageFrameStyle = .none
                 self.addSubview(self.iconView!)
-            }
-            else if (self.icon == nil && self.iconView != nil) {
+            } else if self.icon == nil && self.iconView != nil {
                 self.iconView?.removeFromSuperview()
                 self.iconView = nil
             }
@@ -60,17 +59,16 @@ open class TabButton: NSButton {
             self.needsDisplay = true
         }
     }
-    
-    open var alternativeTitleIcon: NSImage? = nil {
+
+    open var alternativeTitleIcon: NSImage? {
         didSet {
             self.tabButtonCell?.hasTitleAlternativeIcon = (self.alternativeTitleIcon != nil)
-            
+
             if self.alternativeTitleIcon != nil && self.alternativeTitleIconView == nil {
-                self.alternativeTitleIconView = NSImageView(frame: NSZeroRect)
+                self.alternativeTitleIconView = NSImageView(frame: NSRect.zero)
                 self.alternativeTitleIconView?.imageFrameStyle = .none
                 self.addSubview(self.alternativeTitleIconView!)
-            }
-            else if self.alternativeTitleIcon == nil && self.alternativeTitleIconView != nil {
+            } else if self.alternativeTitleIcon == nil && self.alternativeTitleIconView != nil {
                 self.alternativeTitleIconView?.removeFromSuperview()
                 self.alternativeTitleIconView = nil
             }
@@ -78,37 +76,37 @@ open class TabButton: NSButton {
             self.needsDisplay = true
         }
     }
-    
+
     // MARK: - Init
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         self.cell = TabButtonCell(textCell: "")
     }
-    
+
     required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    init(index: Int, item: AnyObject, target: AnyObject?, action:Selector, style: Style) {
-        super.init(frame: NSZeroRect)
+
+    init(index: Int, item: AnyObject, target: AnyObject?, action: Selector, style: Style) {
+        super.init(frame: NSRect.zero)
 
         self.index = index
         self.style = style
 
         let tabCell = TabButtonCell(textCell: "")
-        
+
         tabCell.representedObject = item
         tabCell.imagePosition = .noImage
-        
+
         tabCell.target = target
         tabCell.action = action
         tabCell.style = style
-        
+
         tabCell.sendAction(on: NSEvent.EventTypeMask(rawValue: UInt64(Int(NSEvent.EventTypeMask.leftMouseDown.rawValue))))
         self.cell = tabCell
     }
-    
+
     override open func copy() -> Any {
         let copy = TabButton(frame: self.frame)
         copy.cell = self.cell?.copy() as? NSCell
@@ -119,7 +117,7 @@ open class TabButton: NSButton {
         copy.index = self.index
         return copy
     }
-        
+
     open override var menu: NSMenu? {
         get { return self.cell?.menu }
         set {
@@ -127,43 +125,42 @@ open class TabButton: NSButton {
             self.updateTrackingAreas()
         }
     }
-    
+
     // MARK: - Drawing
 
     open override func updateTrackingAreas() {
         if let ta = self.trackingArea {
             self.removeTrackingArea(ta)
         }
-        
+
         let item: AnyObject? = self.cell?.representedObject as AnyObject?
-        
+
         let userInfo: [String: AnyObject]? = (item != nil) ? ["item": item!] : nil
         self.trackingArea = NSTrackingArea(rect: self.bounds,
                                            options: [NSTrackingArea.Options.mouseEnteredAndExited, NSTrackingArea.Options.activeInActiveApp, NSTrackingArea.Options.inVisibleRect],
                                            owner: self, userInfo: userInfo)
-        
+
         self.addTrackingArea(self.trackingArea!)
-        
+
         if let w = self.window, let e = NSApp.currentEvent {
             let mouseLocation = w.mouseLocationOutsideOfEventStream
             let convertedMouseLocation = self.convert(mouseLocation, from: nil)
-        
-            if NSPointInRect(convertedMouseLocation, self.bounds) {
+
+            if self.bounds.contains(convertedMouseLocation) {
                 self.mouseEntered(with: e)
-            }
-            else {
+            } else {
                 self.mouseExited(with: e)
             }
         }
-        
+
         super.updateTrackingAreas()
     }
-    
+
     open override func mouseEntered(with theEvent: NSEvent) {
         super.mouseEntered(with: theEvent)
         self.needsDisplay = true
     }
-    
+
     open override func mouseExited(with theEvent: NSEvent) {
         super.mouseExited(with: theEvent)
         self.needsDisplay = true
@@ -179,7 +176,7 @@ open class TabButton: NSButton {
     open override func resetCursorRects() {
         self.addCursorRect(self.bounds, cursor: NSCursor.arrow)
     }
-    
+
     open override func draw(_ dirtyRect: NSRect) {
 
         guard let tabButtonCell = self.tabButtonCell
@@ -210,13 +207,12 @@ open class TabButton: NSButton {
         super.draw(dirtyRect)
     }
 
-    
     // MARK: - Editing
-    
+
     internal func edit(fieldEditor: NSText, delegate: NSTextDelegate) {
         self.tabButtonCell?.edit(fieldEditor: fieldEditor, inView: self, delegate: delegate)
     }
-    
+
     internal func finishEditing(fieldEditor: NSText, newValue: String) {
         self.tabButtonCell?.finishEditing(fieldEditor: fieldEditor, newValue: newValue)
     }

--- a/KPCTabsControl/TabButtonCell.swift
+++ b/KPCTabsControl/TabButtonCell.swift
@@ -9,17 +9,16 @@
 import Foundation
 import AppKit
 
-
 let titleMargin: CGFloat = 5.0
 
 class TabButtonCell: NSButtonCell {
-    
+
     var hasTitleAlternativeIcon: Bool = false
 
     var isSelected: Bool {
         get { return self.state == NSControl.StateValue.on }
     }
-    
+
     var selectionState: TabSelectionState {
         return self.isEnabled == false ? TabSelectionState.unselectable : (self.isSelected ? TabSelectionState.selected : TabSelectionState.normal)
     }
@@ -39,7 +38,7 @@ class TabButtonCell: NSButtonCell {
     var style: Style!
 
     // MARK: - Initializers & Copy
-    
+
     override init(textCell aString: String) {
         super.init(textCell: aString)
 
@@ -49,23 +48,23 @@ class TabButtonCell: NSButtonCell {
         self.lineBreakMode = .byTruncatingTail
         self.focusRingType = .none
     }
-    
+
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     override func copy() -> Any {
-        let copy = TabButtonCell(textCell:self.title)
+        let copy = TabButtonCell(textCell: self.title)
 
         copy.hasTitleAlternativeIcon = self.hasTitleAlternativeIcon
         copy.buttonPosition = self.buttonPosition
 
         copy.state = self.state
         copy.isHighlighted = self.isHighlighted
-        
+
         return copy
     }
-    
+
     // MARK: - Properties & Rects
 
     static func popupImage() -> NSImage {
@@ -82,50 +81,48 @@ class TabButtonCell: NSButtonCell {
         let title = self.style.attributedTitle(content: self.title, selectionState: self.selectionState)
         let requiredMinimumWidth = title.size().width + 2.0*titleMargin
         let titleDrawRect = self.titleRect(forBounds: rect)
-        return requiredMinimumWidth <= NSWidth(titleDrawRect)
+        return requiredMinimumWidth <= titleDrawRect.width
     }
 
     override func cellSize(forBounds aRect: NSRect) -> NSSize {
         let title = self.style.attributedTitle(content: self.title, selectionState: self.selectionState)
         let titleSize = title.size()
-        let popupSize = (self.menu == nil) ? NSZeroSize : TabButtonCell.popupImage().size
-        let cellSize = NSMakeSize(titleSize.width + (popupSize.width * 2) + 36, max(titleSize.height, popupSize.height))
+        let popupSize = (self.menu == nil) ? NSSize.zero : TabButtonCell.popupImage().size
+        let cellSize = NSSize(width: titleSize.width + (popupSize.width * 2) + 36, height: max(titleSize.height, popupSize.height))
         self.controlView?.invalidateIntrinsicContentSize()
         return cellSize
     }
-    
+
     fileprivate func popupRectWithFrame(_ cellFrame: NSRect) -> NSRect {
-        var popupRect = NSZeroRect
+        var popupRect = NSRect.zero
         popupRect.size = TabButtonCell.popupImage().size
-        popupRect.origin = NSMakePoint(NSMaxX(cellFrame) - NSWidth(popupRect) - 8, NSMidY(cellFrame) - NSHeight(popupRect) / 2)
+        popupRect.origin = NSPoint(x: cellFrame.maxX - popupRect.width - 8, y: cellFrame.midY - popupRect.height / 2)
         return popupRect
     }
-    
+
     override func trackMouse(with theEvent: NSEvent,
                              in cellFrame: NSRect,
                                     of controlView: NSView,
-                                           untilMouseUp flag: Bool) -> Bool
-    {
+                                           untilMouseUp flag: Bool) -> Bool {
         if self.hitTest(for: theEvent,
                                 in: controlView.superview!.frame,
-                                of: controlView.superview!) != NSCell.HitResult()
-        {
-        
+                                of: controlView.superview!) != NSCell.HitResult() {
+
             let popupRect = self.popupRectWithFrame(cellFrame)
             let location = controlView.convert(theEvent.locationInWindow, from: nil)
-            
-            if self.menu?.items.count > 0 && NSPointInRect(location, popupRect) {
+
+            if self.menu?.items.count > 0 && popupRect.contains(location) {
                 self.menu?.popUp(positioning: self.menu!.items.first,
-                                                    at: NSMakePoint(NSMidX(popupRect), NSMaxY(popupRect)),
+                                                    at: NSPoint(x: popupRect.midX, y: popupRect.maxY),
                                                     in: controlView)
-                
+
                 return true
             }
         }
-        
+
         return super.trackMouse(with: theEvent, in: cellFrame, of: controlView, untilMouseUp: flag)
     }
-    
+
     override func titleRect(forBounds theRect: NSRect) -> NSRect {
         let title = self.style.attributedTitle(content: self.title, selectionState: self.selectionState)
         var rect = self.style.titleRect(title: title, inBounds: theRect, showingIcon: self.showsIcon)
@@ -173,15 +170,15 @@ class TabButtonCell: NSButtonCell {
     }
 
     func editingRectForBounds(_ rect: NSRect) -> NSRect {
-        return self.titleRect(forBounds: rect)//.offsetBy(dx: 0, dy: 1))
+        return self.titleRect(forBounds: rect)// .offsetBy(dx: 0, dy: 1))
     }
-    
+
     // MARK: - Drawing
 
     override func draw(withFrame frame: NSRect, in controlView: NSView) {
 
         self.style.drawTabButtonBezel(frame: frame, position: self.buttonPosition, isSelected: self.isSelected)
-        
+
         if self.hasRoomToDrawFullTitle(inRect: frame) || self.hasTitleAlternativeIcon == false {
             let title = self.style.attributedTitle(content: self.title, selectionState: self.selectionState)
             _ = self.drawTitle(title, withFrame: frame, in: controlView)
@@ -201,7 +198,7 @@ class TabButtonCell: NSButtonCell {
     fileprivate func drawPopupButtonWithFrame(_ frame: NSRect) {
         let image = TabButtonCell.popupImage()
         image.draw(in: self.popupRectWithFrame(frame),
-                         from: NSZeroRect,
+                         from: NSRect.zero,
                          operation: .sourceOver,
                          fraction: 1.0,
                          respectFlipped: true,

--- a/KPCTabsControl/TabsControl.swift
+++ b/KPCTabsControl/TabsControl.swift
@@ -11,16 +11,16 @@ import AppKit
 /// TabsControl is the main class of the library, and is designed to suffice for implementing tabs in your app.
 /// The only necessary thing for it to work is an implementation of its `dataSource`.
 open class TabsControl: NSControl, NSTextDelegate {
-    
-    fileprivate var ScrollViewObservationContext: UnsafeMutableRawPointer? = nil // hm, wrong?
+
+    fileprivate var ScrollViewObservationContext: UnsafeMutableRawPointer? // hm, wrong?
     fileprivate var delegateInterceptor = MessageInterceptor()
 
     fileprivate var scrollView: NSScrollView!
     fileprivate var tabsView: NSView!
 
-    fileprivate var addButton: NSButton? = nil
-    fileprivate var scrollLeftButton: NSButton? = nil
-    fileprivate var scrollRightButton: NSButton? = nil
+    fileprivate var addButton: NSButton?
+    fileprivate var scrollLeftButton: NSButton?
+    fileprivate var scrollRightButton: NSButton?
     fileprivate var hideScrollButtons: Bool = true
 
     fileprivate var editingTab: (title: String, button: TabButton)?
@@ -30,16 +30,16 @@ open class TabsControl: NSControl, NSTextDelegate {
     }
 
     // MARK: - Data Source & Delegate
-    
+
     /// The dataSource of the tabs control, providing all the necessary information for the class to build the tabs.
     @IBOutlet open weak var dataSource: TabsControlDataSource?
-    
+
     /// The delegate of the tabs control, providing additional possibilities for customization and precise behavior.
     @IBOutlet open weak var delegate: TabsControlDelegate? {
         get { return self.delegateInterceptor.receiver as? TabsControlDelegate }
         set { self.delegateInterceptor.receiver = newValue as? NSObject }
     }
-    
+
     // MARK: - Styling
 
     open var style: Style = DefaultStyle() {
@@ -51,24 +51,24 @@ open class TabsControl: NSControl, NSTextDelegate {
     }
 
     // MARK: - Initializers & Setup
-    
+
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.setup()
     }
-    
+
     public override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         self.setup()
     }
-    
+
     fileprivate func setup() {
         self.wantsLayer = true
         self.translatesAutoresizingMaskIntoConstraints = false
         self.cell = TabsControlCell(textCell: "")
         self.configureSubviews()
     }
-    
+
     fileprivate func configureSubviews() {
         self.scrollView = NSScrollView(frame: self.bounds)
         self.scrollView.drawsBackground = false
@@ -79,93 +79,92 @@ open class TabsControl: NSControl, NSTextDelegate {
         self.scrollView.verticalScrollElasticity = .none
         self.scrollView.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
         self.scrollView.translatesAutoresizingMaskIntoConstraints = true
-        
+
         self.tabsView = NSView(frame: self.scrollView.bounds)
         self.scrollView.documentView = self.tabsView
-        
+
         self.addSubview(self.scrollView)
-        
+
         if self.hideScrollButtons == false {
             self.scrollLeftButton = NSButton.auxiliaryButton(withImageNamed: "KPCTabLeftTemplate",
                                                              target: self,
                                                              action: #selector(TabsControl.scrollTabView(_:)))
-            
+
             self.scrollRightButton = NSButton.auxiliaryButton(withImageNamed: "KPCTabRightTemplate",
                                                               target: self,
                                                               action: #selector(TabsControl.scrollTabView(_:)))
-            
+
             self.scrollLeftButton?.autoresizingMask = NSView.AutoresizingMask.minXMargin
             self.scrollLeftButton?.autoresizingMask = NSView.AutoresizingMask.minXMargin
-            
+
             let leftCell = self.scrollLeftButton!.cell as! TabButtonCell
             leftCell.buttonPosition = .first
 
             self.addSubview(self.scrollLeftButton!)
             self.addSubview(self.scrollRightButton!)
-            
+
             // This is typically what's autolayout is supposed to help avoiding.
             // But for pixel-control freaking guys like me, I see no escape.
             var r = CGRect.zero
             r.size.height = self.scrollView.frame.height
             r.size.width = self.scrollLeftButton!.frame.width
             r.origin.x = self.scrollView.frame.maxX - r.size.width
-            self.scrollRightButton!.frame = r;
-            r.origin.x -= r.size.width;
-            self.scrollLeftButton!.frame = r;
+            self.scrollRightButton!.frame = r
+            r.origin.x -= r.size.width
+            self.scrollLeftButton!.frame = r
         }
-        
+
         self.startObservingScrollView()
         self.updateAuxiliaryButtons()
     }
-    
+
     deinit {
         self.stopObservingScrollView()
     }
-    
+
     // MARK: - Public Overrides
 
     open override func menu(for event: NSEvent) -> NSMenu? {
         return nil
     }
-    
+
     // MARK: - Data Source
-    
+
     /**
      Reloads all tabs of the tabs control. Used when the `dataSource` has changed for instance.
      */
     open func reloadTabs() {
         guard let dataSource = self.dataSource else { return }
-                
+
         let oldItemsCount = self.tabButtons.count
         let newItemsCount = dataSource.tabsControlNumberOfTabs(self)
-        
+
         if newItemsCount < oldItemsCount {
             self.tabButtons.filter({ $0.index >= newItemsCount }).forEach({ $0.removeFromSuperview() })
         }
-        
+
         let tabButtons = self.tabButtons
         for i in 0..<newItemsCount {
             let item = dataSource.tabsControl(self, itemAtIndex: i)
-            
-            var button : TabButton
+
+            var button: TabButton
             if i >= oldItemsCount {
                 button = TabButton(index: i,
                                    item: item,
                                    target: self,
                                    action: #selector(TabsControl.selectTab(_:)),
                                    style: self.style)
-                
+
                 button.wantsLayer = true
                 button.state = NSControl.StateValue.off
                 self.tabsView.addSubview(button)
-            }
-            else {
+            } else {
                 button = tabButtons[i]
             }
-            
+
             button.index = i
             button.item = item
-            
+
             button.editable = self.delegate?.tabsControl?(self, canEditTitleOfItem: item) == true
             button.buttonPosition = TabPosition.fromIndex(i, totalCount: newItemsCount)
             button.style = self.style
@@ -173,14 +172,14 @@ open class TabsControl: NSControl, NSTextDelegate {
             button.title = dataSource.tabsControl(self, titleForItem: item)
             button.icon = dataSource.tabsControl?(self, iconForItem: item)
             button.menu = dataSource.tabsControl?(self, menuForItem: item)
-            button.alternativeTitleIcon = dataSource.tabsControl?(self, titleAlternativeIconForItem: item) 
+            button.alternativeTitleIcon = dataSource.tabsControl?(self, titleAlternativeIconForItem: item)
         }
-        
+
         self.layoutTabButtons(nil, animated: false)
         self.updateAuxiliaryButtons()
         self.invalidateRestorableState()
     }
-    
+
     // MARK: - Layout
 
     fileprivate func updateTabs(animated: Bool = false) {
@@ -192,7 +191,7 @@ open class TabsControl: NSControl, NSTextDelegate {
     fileprivate func layoutTabButtons(_ buttons: [TabButton]?, animated: Bool) {
         let tabButtons = buttons ?? self.tabButtons
         var tabsViewWidth = CGFloat(0.0)
-        
+
         let fullWidth = self.scrollView.frame.width / CGFloat(tabButtons.count)
         let buttonHeight = self.tabsView.frame.height
 
@@ -206,7 +205,7 @@ open class TabsControl: NSControl, NSTextDelegate {
 
         var buttonX = CGFloat(0)
         for (index, button) in tabButtons.enumerated() {
-            
+
             let offset = self.style.tabButtonOffset(position: button.buttonPosition)
             let buttonFrame = CGRect(x: buttonX + offset.x, y: offset.y, width: buttonWidth, height: buttonHeight)
             buttonX += buttonWidth + offset.x
@@ -218,7 +217,7 @@ open class TabsControl: NSControl, NSTextDelegate {
             } else {
                 button.frame = buttonFrame
             }
-            
+
             if let selectable = self.delegate?.tabsControl?(self, canSelectItem: button.representedObject!) {
                 button.isEnabled = selectable
             }
@@ -229,19 +228,18 @@ open class TabsControl: NSControl, NSTextDelegate {
         let viewFrame = CGRect(x: 0.0, y: 0.0, width: tabsViewWidth, height: buttonHeight)
         if animated {
             self.tabsView.animator().frame = viewFrame
-        }
-        else {
+        } else {
             self.tabsView.frame = viewFrame
         }
     }
-    
+
     fileprivate func updateAuxiliaryButtons() {
         let contentView = self.scrollView.contentView
-        let showScrollButtons = (contentView.subviews.count > 0) && (NSMaxX(contentView.subviews[0].frame) > NSWidth(contentView.bounds))
-        
+        let showScrollButtons = (contentView.subviews.count > 0) && (contentView.subviews[0].frame.maxX > contentView.bounds.width)
+
         self.scrollLeftButton?.isHidden = !showScrollButtons
         self.scrollRightButton?.isHidden = !showScrollButtons
-        
+
         if showScrollButtons == true {
             self.scrollLeftButton?.isEnabled = self.visibilityCondition(forButton: self.scrollLeftButton!, forLeftHandSide: true)
             self.scrollRightButton?.isEnabled = self.visibilityCondition(forButton: self.scrollRightButton!, forLeftHandSide: false)
@@ -249,47 +247,46 @@ open class TabsControl: NSControl, NSTextDelegate {
     }
 
     // MARK: - ScrollView Observation
-    
+
     fileprivate func startObservingScrollView() {
         // TODO replace this with scroll view change notifications
         self.scrollView.addObserver(self, forKeyPath: "frame", options: .new, context: &ScrollViewObservationContext)
         self.scrollView.addObserver(self, forKeyPath: "documentView.frame", options: .new, context: &ScrollViewObservationContext)
-        
+
         NotificationCenter.default.addObserver(self,
                                                          selector: #selector(TabsControl.scrollViewDidScroll(_:)),
                                                          name: NSView.frameDidChangeNotification,
                                                          object: self.scrollView)
     }
-    
+
     fileprivate func stopObservingScrollView() {
         self.scrollView.removeObserver(self, forKeyPath: "frame", context: &ScrollViewObservationContext)
         self.scrollView.removeObserver(self, forKeyPath: "documentView.frame", context: &ScrollViewObservationContext)
-        
+
         NotificationCenter.default.removeObserver(self,
                                                             name: NSView.frameDidChangeNotification,
                                                             object: self.scrollView)
     }
-    
-    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if context == &ScrollViewObservationContext {
             self.updateAuxiliaryButtons()
-        }
-        else {
+        } else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
     }
-    
+
     @objc fileprivate func scrollViewDidScroll(_ notification: Notification) {
         self.layoutTabButtons(nil, animated: false)
         self.updateAuxiliaryButtons()
         self.invalidateRestorableState()
     }
-    
+
     // MARK: - Actions
-    
+
     @objc fileprivate func scrollTabView(_ sender: AnyObject?) {
         let forLeft = (sender as? NSButton == self.scrollLeftButton)
-            
+
         guard let tab = self.tabButtons.findFirst({ self.visibilityCondition(forButton: $0, forLeftHandSide: forLeft) })
             else { return }
 
@@ -300,36 +297,35 @@ open class TabsControl: NSControl, NSTextDelegate {
                 self.invalidateRestorableState()
         })
     }
-    
+
     fileprivate func visibilityCondition(forButton button: NSButton, forLeftHandSide: Bool) -> Bool {
         let visibleRect = self.tabsView.visibleRect
         if forLeftHandSide == true {
-            return NSMinX(button.frame) < NSMinX(visibleRect)
-        }
-        else {
-            return NSMaxX(button.frame) > NSMaxX(visibleRect) - 2.0*NSWidth(self.scrollLeftButton!.frame)
+            return button.frame.minX < visibleRect.minX
+        } else {
+            return button.frame.maxX > visibleRect.maxX - 2.0*self.scrollLeftButton!.frame.width
         }
     }
-    
+
     // MARK: - Reordering
-    
+
     fileprivate func reorderTab(_ tab: TabButton, withEvent event: NSEvent) {
         var orderedTabs = self.tabButtons
-        let tabX = NSMinX(tab.frame)
+        let tabX = tab.frame.minX
         let dragPoint = self.tabsView.convert(event.locationInWindow, from: nil)
 
         var prevPoint = dragPoint
         var reordered = false
-        
+
         let draggingTab = tab.copy() as! TabButton
         self.addSubview(draggingTab)
         tab.isHidden = true
 
         var temporarySelectedButtonIndex = self.selectedButtonIndex!
-        while(true) {
+        while true {
             let mask: Int = Int(NSEvent.EventTypeMask.leftMouseUp.union(NSEvent.EventTypeMask.leftMouseDragged).rawValue)
             let event: NSEvent! = self.window?.nextEvent(matching: NSEvent.EventTypeMask(rawValue: UInt64(mask)))
-            
+
             if event.type == NSEvent.EventType.leftMouseUp {
                 NSAnimationContext.current.completionHandler = {
                     draggingTab.removeFromSuperview()
@@ -347,35 +343,34 @@ open class TabsControl: NSControl, NSTextDelegate {
                 draggingTab.animator().frame = tab.frame
                 break
             }
-            
+
             let nextPoint = self.tabsView.convert(event.locationInWindow, from: nil)
             let nextX = tabX + (nextPoint.x - dragPoint.x)
-            
+
             var r = draggingTab.frame
             r.origin.x = nextX
             draggingTab.frame = r
-            
+
             let movingLeft = (nextPoint.x < prevPoint.x)
             prevPoint = nextPoint
-            
+
             let primaryIndex = orderedTabs.firstIndex(of: tab)!
-            var secondaryIndex : Int?
-            
-            if movingLeft == true && NSMidX(draggingTab.frame) < NSMinX(tab.frame) && tab !== orderedTabs.first! {
+            var secondaryIndex: Int?
+
+            if movingLeft == true && draggingTab.frame.midX < tab.frame.minX && tab !== orderedTabs.first! {
                 // shift left
                 secondaryIndex = primaryIndex-1
-            }
-            else if movingLeft == false && NSMidX(draggingTab.frame) > NSMaxX(tab.frame) && tab != orderedTabs.last! {
+            } else if movingLeft == false && draggingTab.frame.midX > tab.frame.maxX && tab != orderedTabs.last! {
                 secondaryIndex = primaryIndex+1
             }
-            
+
             if let secondIndex = secondaryIndex {
                 orderedTabs.swapAt(primaryIndex, secondIndex)
-                
+
                 // Shouldn't indexes be swapped too????? But if we do so, it doesn't work!
                 orderedTabs[primaryIndex].buttonPosition = TabPosition.fromIndex(primaryIndex, totalCount: orderedTabs.count)
                 orderedTabs[secondIndex].buttonPosition = TabPosition.fromIndex(secondIndex, totalCount: orderedTabs.count)
-                
+
                 temporarySelectedButtonIndex += secondIndex-primaryIndex
                 self.layoutTabButtons(orderedTabs, animated: true)
                 self.invalidateRestorableState()
@@ -383,7 +378,7 @@ open class TabsControl: NSControl, NSTextDelegate {
             }
         }
     }
-    
+
     // MARK: - Selection
 
     @objc fileprivate func selectTab(_ sender: AnyObject?) {
@@ -398,7 +393,7 @@ open class TabsControl: NSControl, NSTextDelegate {
             let target = self.target {
             NSApp.sendAction(action, to: target, from: self)
         }
-        
+
         NotificationCenter.default.post(name: Notification.Name(rawValue: TabsControlSelectionDidChangeNotification), object: self)
         self.delegate?.tabsControlDidChangeSelection?(self, item: button.representedObject!)
 
@@ -406,8 +401,7 @@ open class TabsControl: NSControl, NSTextDelegate {
 
         if currentEvent.type == .leftMouseDown && currentEvent.clickCount > 1 {
             self.editTabButton(button)
-        }
-        else if let item = button.representedObject
+        } else if let item = button.representedObject
             , self.delegate?.tabsControl?(self, canReorderItem: item) == true {
 
             let mask: NSEvent.EventTypeMask = NSEvent.EventTypeMask.leftMouseUp.union(NSEvent.EventTypeMask.leftMouseDragged)
@@ -435,10 +429,10 @@ open class TabsControl: NSControl, NSTextDelegate {
         return self.tabButtons.findFirst({ $0.index == index })
     }
 
-    var selectedButtonIndex: Int? = nil {
+    var selectedButtonIndex: Int? {
         didSet {
             self.scrollToSelectedButton()
-            
+
             self.updateButtonStatesForSelection()
             self.layoutTabButtons(nil, animated: false)
             self.invalidateRestorableState()
@@ -446,7 +440,7 @@ open class TabsControl: NSControl, NSTextDelegate {
             NotificationCenter.default.post(name: Notification.Name(rawValue: TabsControlSelectionDidChangeNotification), object: self)
         }
     }
-    
+
     /**
      Select an item at a given index. Selecting an invalid index will unselected all tabs.
      
@@ -472,7 +466,7 @@ open class TabsControl: NSControl, NSTextDelegate {
 
     /// Starts editing the tab as if the user double-clicked on it. If `index` is out of bounds, it does nothing.
     open func editTabAtIndex(_ index: Int) {
-        
+
         guard let tabButton = self.tabButtons[safe: index] else { return }
 
         self.editTabButton(tabButton)
@@ -488,37 +482,37 @@ open class TabsControl: NSControl, NSTextDelegate {
             else { return }
 
         self.window?.makeFirstResponder(self)
-        
+
         self.editingTab = (tab.title, tab)
         tab.edit(fieldEditor: fieldEditor, delegate: self)
     }
-    
-    // MARK : - NSTextDelegate
-    
+
+    // MARK: - NSTextDelegate
+
     open func textDidEndEditing(_ notification: Notification) {
         guard let fieldEditor = notification.object as? NSText else {
             assertionFailure("Expected field editor.")
             return
         }
-        
-        let newValue = fieldEditor.string 
+
+        let newValue = fieldEditor.string
         self.editingTab?.button.finishEditing(fieldEditor: fieldEditor, newValue: newValue)
         self.window?.makeFirstResponder(self)
-        
+
         defer {
             self.editingTab = nil
         }
-        
+
         guard let item = self.editingTab?.button.representedObject
             , newValue != self.editingTab?.title
             else { return }
-        
+
         self.delegate?.tabsControl?(self, setTitle: newValue, forItem: item)
         self.editingTab?.button.representedObject = self.dataSource?.tabsControl(self, itemAtIndex: self.selectedButtonIndex!)
     }
 
     // MARK: - Drawing
-    
+
     override open var isOpaque: Bool {
         return false
     }
@@ -526,15 +520,15 @@ open class TabsControl: NSControl, NSTextDelegate {
     override open var isFlipped: Bool {
         return true
     }
-    
+
     // MARK: - Tab Widths
-    
+
     open func currentTabWidth() -> CGFloat {
         let tabs = self.tabButtons
         guard let firstTab = tabs.first else { return 0.0 }
         return firstTab.frame.width
     }
-    
+
     // MARK: - State Restoration
 
     fileprivate enum RestorationKeys {
@@ -544,7 +538,7 @@ open class TabsControl: NSControl, NSTextDelegate {
 
     open override func encodeRestorableState(with coder: NSCoder) {
         super.encodeRestorableState(with: coder)
-        
+
         let scrollXOffset: CGFloat = self.scrollView.contentView.bounds.origin.x
         let selectedButtonIndex: Int = self.selectedButtonIndex ?? NSNotFound
 
@@ -554,10 +548,10 @@ open class TabsControl: NSControl, NSTextDelegate {
 
     open override func restoreState(with coder: NSCoder) {
         super.restoreState(with: coder)
-        
+
         let scrollXOffset = coder.decodeDouble(forKey: RestorationKeys.scrollXOffset)
         let selectedButtonIndex = coder.decodeInteger(forKey: RestorationKeys.selectedButtonIndex)
-        
+
         var bounds = self.scrollView.contentView.bounds
         bounds.origin.x = CGFloat(scrollXOffset)
         self.scrollView.contentView.bounds = bounds
@@ -568,9 +562,9 @@ open class TabsControl: NSControl, NSTextDelegate {
 
         self.selectTab(selectedButton)
     }
-    
+
     // MARK: - Helpers
-    
+
     fileprivate var tabButtons: [TabButton] {
         guard let tabsView = self.tabsView else { return [] }
         return tabsView.subviews.compactMap({ $0 as? TabButton }).sorted(by: { $0.index < $1.index })

--- a/KPCTabsControl/TabsControlCell.swift
+++ b/KPCTabsControl/TabsControlCell.swift
@@ -9,29 +9,29 @@
 import Cocoa
 
 class TabsControlCell: NSCell {
-    
+
     var style: Style! {
         didSet { self.controlView?.needsDisplay = true }
     }
-   
+
     override init(textCell aString: String) {
         super.init(textCell: aString)
-        
+
         self.isBordered = true
         self.backgroundStyle = .light
         self.focusRingType = .none
         self.isEnabled = false
-        self.font = NSFont.systemFont(ofSize: 13)        
+        self.font = NSFont.systemFont(ofSize: 13)
     }
-    
+
     required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     override func cellSize(forBounds aRect: NSRect) -> NSSize {
-        return NSMakeSize(36.0, 0.0)
+        return NSSize(width: 36.0, height: 0.0)
     }
-    
+
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView) {
 
         // TODO can we get rid of this by setting `style` earlier?

--- a/KPCTabsControl/Theme.swift
+++ b/KPCTabsControl/Theme.swift
@@ -31,7 +31,7 @@ public protocol TabsControlTheme {
  */
 public protocol Theme {
     var tabButtonTheme: TabButtonTheme { get }
-    var selectedTabButtonTheme: TabButtonTheme { get }    
+    var selectedTabButtonTheme: TabButtonTheme { get }
     var unselectableTabButtonTheme: TabButtonTheme { get }
     var tabsControlTheme: TabsControlTheme { get }
 }
@@ -44,7 +44,7 @@ extension Theme {
      
      - returns: The theme crresponding to the selection state.
      */
-    public func tabButtonTheme(fromSelectionState selectionState : TabSelectionState) -> TabButtonTheme {
+    public func tabButtonTheme(fromSelectionState selectionState: TabSelectionState) -> TabButtonTheme {
         switch selectionState {
         case .normal: return self.tabButtonTheme
         case .selected: return self.selectedTabButtonTheme

--- a/KPCTabsControlDemo/AppDelegate.swift
+++ b/KPCTabsControlDemo/AppDelegate.swift
@@ -15,8 +15,7 @@ class WorkedAroundWindow: NSWindow {}
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    
-    
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
     }
 
@@ -24,6 +23,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
-
 }
-

--- a/KPCTabsControlDemo/ColoredView.swift
+++ b/KPCTabsControlDemo/ColoredView.swift
@@ -34,8 +34,8 @@ import Cocoa
         guard let borderColor = self.borderColor else { return }
 
         let line = NSBezierPath()
-        line.move(to: NSMakePoint(0, dirtyRect.height))
-        line.line(to: NSMakePoint(dirtyRect.width, dirtyRect.height))
+        line.move(to: NSPoint(x: 0, y: dirtyRect.height))
+        line.line(to: NSPoint(x: dirtyRect.width, y: dirtyRect.height))
         line.lineWidth = 1
         borderColor.setStroke()
         line.stroke()

--- a/KPCTabsControlDemo/PaneViewController.swift
+++ b/KPCTabsControlDemo/PaneViewController.swift
@@ -19,7 +19,7 @@ class Item {
     var menu: NSMenu?
     var altIcon: NSImage?
     var selectable: Bool
-    
+
     init(title: String, icon: NSImage?, menu: NSMenu?, altIcon: NSImage?, selectable: Bool = true) {
         self.title = title
         self.icon = icon
@@ -41,61 +41,61 @@ class PaneViewController: NSViewController, TabsControlDataSource, TabsControlDe
     @IBOutlet weak var useFullWidthTabsCheckButton: NSButton?
     @IBOutlet weak var tabWidthsLabel: NSTextField?
 
-    var items: Array<Item> = []
+    var items: [Item] = []
     override var title: String? {
         didSet { self.tabWidthsLabel?.stringValue = self.title! }
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.tabsBar?.dataSource = self
         self.tabsBar?.delegate = self
         self.tabsBar?.reloadTabs()
     }
-        
+
     // MARK: TabsControlDataSource
-    
+
     func tabsControlNumberOfTabs(_ control: TabsControl) -> Int {
         return self.items.count
     }
-    
+
     func tabsControl(_ control: TabsControl, itemAtIndex index: Int) -> AnyObject {
         return self.items[index]
     }
-    
+
     func tabsControl(_ control: TabsControl, titleForItem item: AnyObject) -> String {
         return (item as! Item).title
     }
-    
+
     // MARK: TabsControlDataSource : Optionals
-    
+
     func tabsControl(_ control: TabsControl, menuForItem item: AnyObject) -> NSMenu? {
         return (item as! Item).menu
     }
-    
+
     func tabsControl(_ control: TabsControl, iconForItem item: AnyObject) -> NSImage? {
         return (item as! Item).icon
     }
-    
+
     func tabsControl(_ control: TabsControl, titleAlternativeIconForItem item: AnyObject) -> NSImage? {
         return (item as! Item).altIcon
     }
 
     // MARK: TabsControlDelegate
-    
+
     func tabsControl(_ control: TabsControl, canReorderItem item: AnyObject) -> Bool {
         return true
     }
-    
+
     func tabsControl(_ control: TabsControl, didReorderItems items: [AnyObject]) {
         self.items = items.map { $0 as! Item }
     }
-    
+
     func tabsControl(_ control: TabsControl, canEditTitleOfItem: AnyObject) -> Bool {
         return true
     }
-    
+
     func tabsControl(_ control: TabsControl, setTitle newTitle: String, forItem item: AnyObject) {
         let typedItem = item as! Item
         let titles = self.items.map { $0.title }
@@ -110,4 +110,3 @@ class PaneViewController: NSViewController, TabsControlDataSource, TabsControlDe
         return (item as! Item).selectable
     }
 }
-

--- a/KPCTabsControlDemo/ViewController.swift
+++ b/KPCTabsControlDemo/ViewController.swift
@@ -13,13 +13,13 @@ class ViewController: NSViewController {
     @IBOutlet var paneDefault: PaneViewController?
     @IBOutlet var paneChrome: PaneViewController?
     @IBOutlet var paneSafari: PaneViewController?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.paneDefault?.title = "Default (~Numbers.app)"
         self.paneDefault?.tabsBar?.style = DefaultStyle()
-        
+
         let tab2Menu = NSMenu()
         tab2Menu.addItem(withTitle: "Action 1: AddTabItem", action: #selector(ViewController.addTabItem), keyEquivalent: "")
         tab2Menu.addItem(withTitle: "Action 2: nil", action: nil, keyEquivalent: "")
@@ -42,7 +42,7 @@ class ViewController: NSViewController {
 
         let style = self.paneChrome?.tabsBar?.style as! ThemedStyle
         (self.paneChrome?.view as? ColoredView)?.backgroundColor = style.theme.selectedTabButtonTheme.backgroundColor
-        
+
         self.paneChrome?.tabsBar?.reloadTabs()
         self.paneChrome?.tabsBar?.selectItemAtIndex(3)
 
@@ -56,7 +56,7 @@ class ViewController: NSViewController {
         self.paneSafari?.tabsBar?.reloadTabs()
         self.paneSafari?.tabsBar?.selectItemAtIndex(1)
     }
-    
+
     @objc func addTabItem() {
         let title = "New Tab #\(paneDefault!.items.count + 1)"
         print("add tab item \(title)...")
@@ -64,4 +64,3 @@ class ViewController: NSViewController {
         paneDefault?.tabsBar?.reloadTabs()
     }
 }
-

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "KPCTabsControl",
     platforms: [
-        .macOS(.v10_14),
+        .macOS(.v10_14)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
I noticed that some files had trailing whitespace. To avoid noise elsewhere, I ran `swiftlint --fix` on the project to help modernize Swift (NSMakeRect → NSRect.init, remove semicolons, ...)

This is all very optional and we can just as well discard this PR, @onekiloparsec, if you don't like the effect of this