### PR TITLE
Add Privacy Manifest

### DIFF
--- a/KPCTabsControl.podspec
+++ b/KPCTabsControl.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Cédric Foellmi" => "cedric@onekilopars.ec" }
   s.source       = { :git => "https://github.com/onekiloparsec/KPCTabsControl.git", :tag => "#{s.version}" }
   s.source_files = 'KPCTabsControl/*.{swift}'
+  s.resource_bundles = {'KPCTabsControl' => ['Resources/*.xcprivacy']}
   s.platform     = :osx, '10.14'
   s.framework    = 'QuartzCore', 'AppKit'
   s.resources    = 'Resources/*.pdf'

--- a/KPCTabsControl.xcodeproj/project.pbxproj
+++ b/KPCTabsControl.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		501FD7771D5B2A0100C3B1F3 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501FD7761D5B2A0100C3B1F3 /* Style.swift */; };
 		501FD7791D5B2CA300C3B1F3 /* DefaultTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 501FD7781D5B2CA300C3B1F3 /* DefaultTheme.swift */; };
 		508829A51D61A1FA00678DF3 /* CollectionType+TabsControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508829A41D61A1FA00678DF3 /* CollectionType+TabsControl.swift */; };
+		50B575E12BEE58C8006C9262 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 50B575E02BEE58C8006C9262 /* PrivacyInfo.xcprivacy */; };
 		50BF2D711D5F09A8006A54F5 /* ChromeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BF2D701D5F09A8006A54F5 /* ChromeStyle.swift */; };
 		50BF2D731D5F1C44006A54F5 /* ColoredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BF2D721D5F1C44006A54F5 /* ColoredView.swift */; };
 		9F0505531D717CF8003D542B /* SafariTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0505521D717CF8003D542B /* SafariTheme.swift */; };
@@ -80,6 +81,7 @@
 		501FD7761D5B2A0100C3B1F3 /* Style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Style.swift; path = KPCTabsControl/Style.swift; sourceTree = "<group>"; };
 		501FD7781D5B2CA300C3B1F3 /* DefaultTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DefaultTheme.swift; path = KPCTabsControl/DefaultTheme.swift; sourceTree = "<group>"; };
 		508829A41D61A1FA00678DF3 /* CollectionType+TabsControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CollectionType+TabsControl.swift"; path = "KPCTabsControl/CollectionType+TabsControl.swift"; sourceTree = "<group>"; };
+		50B575E02BEE58C8006C9262 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = file; name = PrivacyInfo.xcprivacy; path = Resources/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		50BF2D701D5F09A8006A54F5 /* ChromeStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChromeStyle.swift; path = KPCTabsControl/ChromeStyle.swift; sourceTree = "<group>"; };
 		50BF2D721D5F1C44006A54F5 /* ColoredView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColoredView.swift; sourceTree = "<group>"; };
 		9F0505521D717CF8003D542B /* SafariTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariTheme.swift; path = KPCTabsControl/SafariTheme.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 		9FA7EDA71AD668BC0060FF79 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				50B575E02BEE58C8006C9262 /* PrivacyInfo.xcprivacy */,
 				9F6E61DC1D4F6E9B004167F1 /* README.md */,
 				9F1F12961D7C5D8A006FD828 /* KPCTabsControl.podspec */,
 				9F494B18247837DB006EFC40 /* Package.swift */,
@@ -414,6 +417,7 @@
 				9FA7EDD01AD66A250060FF79 /* KPCTabPlusTemplate.pdf in Resources */,
 				9FA7EDCF1AD66A250060FF79 /* KPCTabLeftTemplate.pdf in Resources */,
 				9FA7EDD11AD66A250060FF79 /* KPCTabRightTemplate.pdf in Resources */,
+				50B575E12BEE58C8006C9262 /* PrivacyInfo.xcprivacy in Resources */,
 				9FA7EDCE1AD66A250060FF79 /* KPCPullDownTemplate.pdf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
             name: "KPCTabsControl",
             path: "KPCTabsControl",
             resources: [
-                .copy("Resources")
+                .process("Resources/PrivacyInfo.xcprivacy"),
+                .copy("Resources"),
             ],
             swiftSettings: [.define("SwiftPackage")]
         )

--- a/Resources/PrivacyInfo.xcprivacy
+++ b/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
- Xcode .framework build contains the manifest,
- `pod lib lint` doesn't complain, and 
- `swift build` also works.

Not yet required on macOS, but I was upgrading stuff anyway :)